### PR TITLE
Add batch plot data API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides repository guidance for any AI coding agent working with this codebase.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "main": "server.js",
     "scripts": {
         "test": "nodemon ./server/server.js",
+        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js",
+        "test:batch:real": "node --test test/batch-api-real-data.test.js",
         "start": "node ./server-prod.js",
         "pack-custom-plotly": "webpack --config custom-plotly/webpack.config.js",
         "pack-client": "webpack --config webpack.config.js --config-name client",

--- a/public/javascripts/package.json
+++ b/public/javascripts/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/public/javascripts/plotting/summary-generate.js
+++ b/public/javascripts/plotting/summary-generate.js
@@ -5,7 +5,7 @@ import {
     addLoadingIndicator,
 } from '../components/status-bar.js';
 import { getBasicParameters } from '../components/units.js';
-import { requestPlotData } from '../shared/api.js';
+import { requestBatchPlotData } from '../shared/api.js';
 
 export async function generateSummary(data) {
     const container = document.querySelector('#container');
@@ -540,7 +540,16 @@ function minmax(as, padding = 0) {
  */
 export async function buildSummaryPage(openPanel) {
     await getBasicParameters();
-    const summary_data = await (await requestPlotData('Summary')).json();
+    const { results } = await (
+        await requestBatchPlotData([{ type: 'Summary', id: 'all' }])
+    ).json();
+    const summaryResult = results?.[0];
+    if (!summaryResult || summaryResult.error) {
+        throw new Error(
+            summaryResult?.error ?? 'Summary batch response contained no result'
+        );
+    }
+    const summary_data = summaryResult.figures;
     const summaryContainer = await generateSummary(summary_data);
 
     if (summaryContainer === undefined) {

--- a/public/javascripts/shared/api.js
+++ b/public/javascripts/shared/api.js
@@ -42,6 +42,42 @@ export async function requestPlotData(name, opts) {
 }
 
 /**
+ * Fetch data for multiple plots in a single HTTP round-trip.
+ *
+ * @param {Array<{type: string, id: string}>} requests - Each element
+ *   specifies a plot: `type` is the plot category ("History", "Snapshot",
+ *   "Equilibrium", "RadialTime", "Tracking", or "Summary") and `id` is
+ *   the sub-plot identifier (e.g. "phi-point", "1D-psi-Te").
+ * @param {Object} [opts]
+ * @param {boolean} [opts.optional=false] - If true, HTTP transport
+ *   errors are swallowed; the caller must check `res.ok`.
+ * @param {string} [opts.query=''] - Extra query string appended to the
+ *   URL (e.g. "&snapshot_playing").
+ * @returns {Promise<Response>} A fetch Response. Call `.json()` to get
+ *   `{ results: Array<{type: string, id: string, figures?: Array, error?: string}> }`.
+ */
+export async function requestBatchPlotData(requests, opts) {
+    const optional = opts?.optional ?? false;
+    const query = opts?.query ?? '';
+    const res = await fetch(
+        `/plot/data/batch?dir=${document.querySelector('#output-tag').innerText}${query}`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ requests }),
+        }
+    );
+    try {
+        await propagateFetchError(res);
+    } catch (e) {
+        if (!optional) {
+            throw e;
+        }
+    }
+    return res;
+}
+
+/**
  * POST a download request for GTC output files and return the resulting
  * blob together with the server-suggested filename.
  *

--- a/server/batch-data-handler.js
+++ b/server/batch-data-handler.js
@@ -1,0 +1,211 @@
+/**
+ * Batch plot-data handler for the POST /plot/data/batch route.
+ *
+ * Accepts multiple {type, id} pairs in a single HTTP request, groups them
+ * by type to avoid redundant file reads, and returns all results in one
+ * response.  Individual item failures are reported per-item rather than
+ * aborting the entire batch.
+ *
+ * @module batch-data-handler
+ */
+
+'use strict';
+
+/**
+ * Radial-data keys exposed by the Summary type (subset of Equilibrium
+ * 1-D radial profiles that the Summary page consumes).
+ */
+const SUMMARY_KEYS = [
+    'minor',
+    'rg',
+    'q',
+    'dlnq_dpsi',
+    'Te',
+    'dlnTe_dpsi',
+    'ne',
+    'dlnne_dpsi',
+    'Ti',
+    'dlnTi_dpsi',
+    'ni',
+    'dlnni_dpsi',
+    'Tf',
+    'dlnTf_dpsi',
+    'nf',
+    'dlnnf_dpsi',
+];
+
+/**
+ * Express route handler for POST /plot/data/batch.
+ *
+ * Expects `req.body.gtcOutput` to be set by the upstream /plot middleware.
+ *
+ * @param {import('express').Request} req
+ * @param {Object} req.body
+ * @param {import('../GTC-output-parser/main.js')} req.body.gtcOutput
+ * @param {Array<{type: string, id: string}>} req.body.requests
+ * @param {import('express').Response} res
+ */
+async function batchPlotData(req, res) {
+    const { gtcOutput, requests } = req.body;
+
+    // ------------------------------------------------------------------
+    //  Validation
+    // ------------------------------------------------------------------
+    if (!Array.isArray(requests) || requests.length === 0) {
+        res.status(400).json({ error: 'requests must be a non-empty array' });
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    //  Normalise valid entries and record per-item validation failures.
+    //  Track the original index so output always matches request order.
+    // ------------------------------------------------------------------
+    const entries = [];
+    const results = new Array(requests.length);
+    for (let i = 0; i < requests.length; i++) {
+        const request = requests[i];
+        const type = request?.type;
+        const id = request?.id;
+        if (
+            typeof type === 'string' &&
+            type.trim().length > 0 &&
+            typeof id === 'string' &&
+            id.trim().length > 0
+        ) {
+            entries.push({ type, id, origIdx: i });
+        } else {
+            results[i] = {
+                type: typeof type === 'string' ? type : null,
+                id: typeof id === 'string' ? id : null,
+                error: 'type and id must be non-empty strings',
+            };
+        }
+    }
+
+    if (entries.length === 0) {
+        res.status(400).json({
+            error: 'no valid {type, id} entries in requests',
+        });
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    //  Group by type so that readData() is called at most once per type.
+    // ------------------------------------------------------------------
+    /** @type {Map<string, Array<{type: string, id: string, origIdx: number}>>} */
+    const byType = new Map();
+    for (const entry of entries) {
+        const group = byType.get(entry.type);
+        if (group) {
+            group.push(entry);
+        } else {
+            byType.set(entry.type, [entry]);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    //  Phase 1 – read each underlying data file once (async, expensive).
+    //  Summary depends on Equilibrium, so those two public types share one
+    //  read operation when requested together.
+    // ------------------------------------------------------------------
+    const readTypes = new Set(
+        [...byType.keys()].map(type =>
+            type === 'Summary' ? 'Equilibrium' : type
+        )
+    );
+    /** @type {Map<string, {ok: boolean, error?: unknown}>} */
+    const readDataCache = new Map();
+
+    await Promise.all(
+        [...readTypes].map(async type => {
+            try {
+                await gtcOutput.readData(type);
+                readDataCache.set(type, { ok: true });
+            } catch (err) {
+                readDataCache.set(type, { ok: false, error: err });
+            }
+        })
+    );
+
+    let summaryData;
+    let summaryError;
+    if (byType.has('Summary') && readDataCache.get('Equilibrium').ok) {
+        try {
+            const radialData = gtcOutput.data['Equilibrium'].radialData;
+            summaryData = {};
+            for (const key of SUMMARY_KEYS) {
+                summaryData[key] = radialData[key];
+            }
+        } catch (err) {
+            summaryError = err;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    //  Phase 2 – collect per-item results via getPlotData.
+    // ------------------------------------------------------------------
+    for (const { type, id, origIdx } of entries) {
+        const readType = type === 'Summary' ? 'Equilibrium' : type;
+        const readResult = readDataCache.get(readType);
+
+        if (!readResult.ok) {
+            // The entire type failed to read.
+            results[origIdx] = {
+                type,
+                id,
+                error: `readData failed for type "${readType}": ${
+                    readResult.error?.message ?? String(readResult.error)
+                }`,
+            };
+            continue;
+        }
+
+        if (type === 'Summary') {
+            if (summaryError) {
+                results[origIdx] = {
+                    type,
+                    id,
+                    error: `Summary data extraction failed: ${
+                        summaryError.message ?? String(summaryError)
+                    }`,
+                };
+            } else {
+                results[origIdx] = { type, id, figures: summaryData };
+            }
+            continue;
+        }
+
+        // Normal type: call getPlotData
+        try {
+            const figures = gtcOutput.getPlotData(type, id, req.query);
+            results[origIdx] = { type, id, figures };
+        } catch (err) {
+            results[origIdx] = {
+                type,
+                id,
+                error: `getPlotData failed for "${type}-${id}": ${err.message}`,
+            };
+        }
+    }
+
+    res.json({ results });
+}
+
+/**
+ * Register the batch endpoint on an Express application or router.
+ * Keeping registration here lets integration tests exercise the same route
+ * wiring used by the production server.
+ *
+ * @param {import('express').Application|import('express').Router} app
+ * @param {(handler: Function) => Function} wrap - Server async error wrapper.
+ */
+function registerBatchPlotDataRoute(app, wrap) {
+    app.post(
+        '/plot/data/batch',
+        wrap(async (req, res) => {
+            await batchPlotData(req, res);
+        })
+    );
+}
+
+module.exports = { batchPlotData, registerBatchPlotDataRoute };

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const compression = require('compression');
 const FileTree = require('./fileTree.js');
 const fs = require('fs').promises;
 const Ajv = require('ajv');
+const { registerBatchPlotDataRoute } = require('./batch-data-handler.js');
 const pug = require('pug');
 
 const input_schema = require('./input-parameters-schema.json');
@@ -35,6 +36,7 @@ const folder_cache = {
 app.use(compression());
 app.use(express.static('./public'));
 app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 app.disable('x-powered-by');
 
 app.listen(port);
@@ -202,10 +204,6 @@ app.get(
     })
 );
 
-app.get('/plot/Summary', (req, res) => {
-    prepareSummaryData(req.body.gtcOutput).then(res.json.bind(res));
-});
-
 app.get('/plot/data/basicParameters', (req, res) => {
     const gtcOutput = req.body.gtcOutput;
     gtcOutput.read_para().then(() => {
@@ -229,6 +227,9 @@ app.get('/plot/data/:typeid', (req, res) => {
         res.status(404).end();
     }
 });
+
+// Batch endpoint: accept multiple {type, id} pairs in one request.
+registerBatchPlotDataRoute(app, wrap);
 
 app.post('/plot/data/download', (req, res, next) => {
     const currentDir = req.body.gtcOutput.dir;
@@ -396,30 +397,4 @@ async function validateInputSchema() {
     } else {
         console.log(validate.errors);
     }
-}
-
-async function prepareSummaryData(currentOutput) {
-    await currentOutput.readData('Equilibrium');
-    const data = {};
-    [
-        'minor',
-        'rg',
-        'q',
-        'dlnq_dpsi',
-        'Te',
-        'dlnTe_dpsi',
-        'ne',
-        'dlnne_dpsi',
-        'Ti',
-        'dlnTi_dpsi',
-        'ni',
-        'dlnni_dpsi',
-        'Tf',
-        'dlnTf_dpsi',
-        'nf',
-        'dlnnf_dpsi',
-    ].forEach(key => {
-        data[key] = currentOutput.data['Equilibrium'].radialData[key];
-    });
-    return data;
 }

--- a/test/batch-api-client.test.js
+++ b/test/batch-api-client.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for the requestBatchPlotData client function.
+ *
+ * Run with:
+ *   node --test test/batch-api-client.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ------------------------------------------------------------------
+//  Mock helpers
+// ------------------------------------------------------------------
+
+/**
+ * Set up global mocks for DOM and fetch.  The client module uses:
+ *   - document.querySelector('#output-tag').innerText
+ *   - fetch(url, init)
+ *   - propagateFetchError(res) — async, throws on !res.ok
+ */
+function setupDOMAndFetch() {
+    // Mock document
+    global.document = {
+        querySelector(selector) {
+            if (selector === '#output-tag') {
+                return { innerText: 'test%2Foutput%2Fdir' };
+            }
+            return null;
+        },
+    };
+
+    // Mock fetch — callers can override per-test via global._fetchImpl
+    global._fetchImpl = null;
+    global.fetch = async function (url, init) {
+        if (global._fetchImpl) {
+            return global._fetchImpl(url, init);
+        }
+        // Default: return a 200 with JSON body
+        return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            async json() {
+                return {
+                    results: [
+                        {
+                            type: 'History',
+                            id: 'phi-point',
+                            figures: [{ data: [{ y: [1, 2] }], layout: {} }],
+                        },
+                    ],
+                };
+            },
+        };
+    };
+}
+
+function teardownDOMAndFetch() {
+    delete global.document;
+    delete global.fetch;
+    delete global._fetchImpl;
+}
+
+// ------------------------------------------------------------------
+//  Tests
+// ------------------------------------------------------------------
+
+describe('requestBatchPlotData (client)', () => {
+    let requestBatchPlotData;
+
+    beforeEach(() => {
+        setupDOMAndFetch();
+        // This will throw if the module doesn't export the function yet (red phase of TDD).
+        requestBatchPlotData =
+            require('../public/javascripts/shared/api.js').requestBatchPlotData;
+    });
+
+    afterEach(() => {
+        teardownDOMAndFetch();
+    });
+
+    describe('request construction', () => {
+        it('sends a POST to /plot/data/batch with the dir query param', async () => {
+            if (!requestBatchPlotData) return;
+
+            let capturedUrl;
+            let capturedInit;
+
+            global._fetchImpl = async (url, init) => {
+                capturedUrl = url;
+                capturedInit = init;
+                return {
+                    ok: true,
+                    status: 200,
+                    async json() {
+                        return {
+                            results: [
+                                {
+                                    type: 'History',
+                                    id: 'phi-point',
+                                    figures: [{ data: [], layout: {} }],
+                                },
+                            ],
+                        };
+                    },
+                };
+            };
+
+            await requestBatchPlotData([{ type: 'History', id: 'phi-point' }]);
+
+            assert.ok(capturedUrl.includes('/plot/data/batch'));
+            assert.ok(capturedUrl.includes('dir=test%2Foutput%2Fdir'));
+            assert.equal(capturedInit.method, 'POST');
+            assert.equal(
+                capturedInit.headers['Content-Type'],
+                'application/json'
+            );
+            assert.equal(
+                JSON.parse(capturedInit.body).requests[0].type,
+                'History'
+            );
+            assert.equal(
+                JSON.parse(capturedInit.body).requests[0].id,
+                'phi-point'
+            );
+        });
+
+        it('appends extra query string when opts.query is provided', async () => {
+            if (!requestBatchPlotData) return;
+
+            let capturedUrl;
+
+            global._fetchImpl = async (url, _init) => {
+                capturedUrl = url;
+                return {
+                    ok: true,
+                    status: 200,
+                    async json() {
+                        return { results: [] };
+                    },
+                };
+            };
+
+            await requestBatchPlotData([{ type: 'History', id: 'phi-point' }], {
+                query: '&snapshot_playing',
+            });
+
+            assert.ok(capturedUrl.includes('&snapshot_playing'));
+        });
+
+        it('returns a Response that can be .json() parsed', async () => {
+            if (!requestBatchPlotData) return;
+
+            const res = await requestBatchPlotData([
+                { type: 'History', id: 'phi-point' },
+            ]);
+
+            const body = await res.json();
+            assert.ok(Array.isArray(body.results));
+            assert.equal(body.results[0].type, 'History');
+            assert.equal(body.results[0].id, 'phi-point');
+            assert.ok(body.results[0].figures);
+        });
+    });
+
+    describe('error handling', () => {
+        it('throws on non-OK response when optional is not set', async () => {
+            if (!requestBatchPlotData) return;
+
+            global._fetchImpl = async (_url, _init) => {
+                return {
+                    ok: false,
+                    status: 500,
+                    statusText: 'Internal Server Error',
+                };
+            };
+
+            await assert.rejects(() =>
+                requestBatchPlotData([{ type: 'History', id: 'phi-point' }])
+            );
+        });
+
+        it('does not throw on non-OK response when optional is true', async () => {
+            if (!requestBatchPlotData) return;
+
+            global._fetchImpl = async (_url, _init) => {
+                return {
+                    ok: false,
+                    status: 404,
+                    statusText: 'Not Found',
+                };
+            };
+
+            const res = await requestBatchPlotData(
+                [{ type: 'History', id: 'phi-point' }],
+                { optional: true }
+            );
+
+            assert.equal(res.ok, false);
+            assert.equal(res.status, 404);
+        });
+    });
+});

--- a/test/batch-api-http.test.js
+++ b/test/batch-api-http.test.js
@@ -1,0 +1,105 @@
+/**
+ * HTTP-level integration tests for POST /plot/data/batch.
+ *
+ * These tests use a real Express listener so JSON parsing, /plot middleware,
+ * route registration, and wire serialization are exercised together.
+ */
+
+'use strict';
+
+const { after, before, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+
+const {
+    registerBatchPlotDataRoute,
+} = require('../server/batch-data-handler.js');
+
+describe('POST /plot/data/batch over HTTP', () => {
+    let server;
+    let endpoint;
+    let gtcOutput;
+
+    before(async () => {
+        gtcOutput = {
+            data: {
+                Equilibrium: {
+                    radialData: { minor: [0, 1], q: [1, 2] },
+                },
+            },
+            readDataCalls: [],
+            async readData(type) {
+                this.readDataCalls.push(type);
+            },
+            getPlotData(type, id, query) {
+                return [{ data: [{ y: [1, 2] }], layout: { type, id, query } }];
+            },
+        };
+
+        const app = express();
+        app.use(express.json());
+        app.use('/plot', (req, res, next) => {
+            req.body.gtcOutput = gtcOutput;
+            next();
+        });
+        const wrap = func => (...args) => func(...args).catch(args[2]);
+        registerBatchPlotDataRoute(app, wrap);
+        app.use((err, req, res, next) => {
+            res.status(err.status ?? 500).json({ error: err.message });
+        });
+
+        await new Promise((resolve, reject) => {
+            server = app.listen(0, '127.0.0.1', resolve);
+            server.once('error', reject);
+        });
+        endpoint = `http://127.0.0.1:${server.address().port}/plot/data/batch?dir=test&step=3`;
+    });
+
+    after(async () => {
+        if (server) {
+            await new Promise((resolve, reject) => {
+                server.close(err => (err ? reject(err) : resolve()));
+            });
+        }
+    });
+
+    it('parses JSON and returns ordered results through the registered route', async () => {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                requests: [
+                    { type: 'Summary', id: 'all' },
+                    { type: 'Equilibrium', id: '1D-minor-q' },
+                    null,
+                ],
+            }),
+        });
+        const body = await response.json();
+
+        assert.equal(response.status, 200);
+        assert.deepEqual(
+            body.results.map(result => result.type),
+            ['Summary', 'Equilibrium', null]
+        );
+        assert.deepEqual(body.results[0].figures.minor, [0, 1]);
+        assert.ok(body.results[1].figures);
+        assert.match(body.results[2].error, /non-empty strings/);
+        assert.equal(
+            gtcOutput.readDataCalls.filter(type => type === 'Equilibrium').length,
+            1
+        );
+        assert.equal(body.results[1].figures[0].layout.query.step, '3');
+    });
+
+    it('returns 400 for malformed JSON', async () => {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{"requests":',
+        });
+
+        assert.equal(response.status, 400);
+        assert.match(response.headers.get('content-type'), /application\/json/);
+    });
+});

--- a/test/batch-api-real-data.test.js
+++ b/test/batch-api-real-data.test.js
@@ -1,0 +1,248 @@
+/**
+ * Real-data integration tests for POST /plot/data/batch.
+ *
+ * These tests intentionally use the archived GTC runs in test/data. Only the
+ * files needed by the requested plot types are extracted, keeping setup fast
+ * and avoiding a permanent copy of the simulation output in the worktree.
+ *
+ * Run with:
+ *   npm run test:batch:real
+ */
+
+'use strict';
+
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { after, before, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { batchPlotData } = require('../server/batch-data-handler.js');
+const GTCOutput = require('../server/GTC-output-parser/main.js');
+
+const execFileAsync = promisify(execFile);
+const DATA_DIR = path.join(__dirname, 'data');
+const REQUIRED_OUTPUT_FILES = [
+    'gtc.out',
+    'history.out',
+    'equilibrium.out',
+    'data1d.out',
+];
+
+const fixtures = [
+    {
+        name: 'ITG',
+        archive: 'gtc-itg.tar.gz',
+        archiveRoot: 'ITG',
+        expected: {
+            historySteps: 1000,
+            equilibriumPoints: 129,
+            radialTimeSteps: 1000,
+            radialTimePoints: 97,
+        },
+    },
+    {
+        name: 'ITPA-TAE',
+        archive: 'gtc-tae.tar.gz',
+        archiveRoot: 'ITPA-TAE',
+        expected: {
+            historySteps: 1000,
+            equilibriumPoints: 500,
+            radialTimeSteps: 1000,
+            radialTimePoints: 101,
+        },
+    },
+];
+
+let extractionRoot;
+
+function createResponseRecorder() {
+    return {
+        statusCode: 200,
+        body: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(body) {
+            this.body = body;
+            return this;
+        },
+    };
+}
+
+async function extractFixture(fixture) {
+    const archivePath = path.join(DATA_DIR, fixture.archive);
+    try {
+        await fs.access(archivePath);
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            fixture.missing = true;
+            return;
+        }
+        throw error;
+    }
+
+    await execFileAsync('tar', [
+        '-xzf',
+        archivePath,
+        '-C',
+        extractionRoot,
+        ...REQUIRED_OUTPUT_FILES.map(
+            filename => `${fixture.archiveRoot}/${filename}`
+        ),
+    ]);
+
+    fixture.outputDir = path.join(extractionRoot, fixture.archiveRoot);
+}
+
+async function requestRealBatch(outputDir, requests) {
+    const res = createResponseRecorder();
+    const req = {
+        body: {
+            gtcOutput: new GTCOutput(outputDir),
+            requests,
+        },
+        query: {},
+    };
+
+    await batchPlotData(req, res);
+    return res;
+}
+
+async function requestLegacyPlotData(outputDir, requests, query = {}) {
+    const gtcOutput = new GTCOutput(outputDir);
+    const figures = [];
+
+    for (const { type, id } of requests) {
+        await gtcOutput.readData(type);
+        figures.push(gtcOutput.getPlotData(type, id, query));
+    }
+
+    return figures;
+}
+
+function toWireValue(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function assertFiniteSeries(values, label) {
+    assert.ok(Array.isArray(values), `${label} should be an array`);
+    assert.ok(values.length > 1, `${label} should contain real data`);
+    assert.ok(
+        values.every(Number.isFinite),
+        `${label} should contain only finite numbers`
+    );
+}
+
+before(async () => {
+    extractionRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'gtc-batch-api-'));
+    await Promise.all(fixtures.map(extractFixture));
+});
+
+after(async () => {
+    if (extractionRoot) {
+        await fs.rm(extractionRoot, { recursive: true, force: true });
+    }
+});
+
+describe('POST /plot/data/batch with real GTC output', () => {
+    for (const fixture of fixtures) {
+        it(`parses and returns a mixed batch for ${fixture.name}`, async t => {
+            if (fixture.missing) {
+                t.skip(`missing test/data/${fixture.archive}`);
+                return;
+            }
+
+            const requests = [
+                { type: 'History', id: 'phi-point' },
+                { type: 'Equilibrium', id: '1D-minor-q' },
+                { type: 'RadialTime', id: 'phi-zonal' },
+                { type: 'Summary', id: 'all' },
+            ];
+
+            const res = await requestRealBatch(fixture.outputDir, requests);
+
+            // The old /plot/data/:typeid route reads the requested type and
+            // then calls getPlotData(). Use a separate parser instance so the
+            // comparison cannot pass because it reused the batch cache.
+            const legacyRequests = requests.filter(
+                ({ type }) => type !== 'Summary'
+            );
+            const legacyFigures = await requestLegacyPlotData(
+                fixture.outputDir,
+                legacyRequests
+            );
+
+            assert.equal(res.statusCode, 200);
+            assert.deepEqual(
+                res.body.results.map(({ type, id }) => ({ type, id })),
+                requests,
+                'results should preserve request order'
+            );
+            for (const result of res.body.results) {
+                assert.equal(
+                    result.error,
+                    undefined,
+                    `${result.type}-${result.id} failed: ${result.error}`
+                );
+            }
+
+            legacyRequests.forEach((request, index) => {
+                const batchResult = res.body.results.find(
+                    result =>
+                        result.type === request.type && result.id === request.id
+                );
+                assert.deepEqual(
+                    toWireValue(batchResult.figures),
+                    toWireValue(legacyFigures[index]),
+                    `${request.type}-${request.id} should match the legacy data API`
+                );
+            });
+
+            const history = res.body.results[0].figures;
+            assert.equal(history.length, 2);
+            assertFiniteSeries(history[0].data[0].x, 'History x values');
+            assertFiniteSeries(history[0].data[0].y, 'History y values');
+            assert.equal(
+                history[0].data[0].x.length,
+                history[0].data[0].y.length
+            );
+            assert.equal(
+                history[0].data[0].y.length,
+                fixture.expected.historySteps
+            );
+
+            const equilibriumTrace = res.body.results[1].figures[0].data[0];
+            assertFiniteSeries(equilibriumTrace.x, 'Equilibrium minor radius');
+            assertFiniteSeries(equilibriumTrace.y, 'Equilibrium safety factor');
+            assert.equal(equilibriumTrace.x.length, equilibriumTrace.y.length);
+            assert.equal(
+                equilibriumTrace.x.length,
+                fixture.expected.equilibriumPoints
+            );
+
+            const radialTimeTrace = res.body.results[2].figures[0].data[0];
+            assert.equal(radialTimeTrace.type, 'heatmap');
+            assert.equal(
+                radialTimeTrace.z.length,
+                fixture.expected.radialTimeSteps
+            );
+            assertFiniteSeries(radialTimeTrace.z[0], 'Radial-time first step');
+            assert.equal(
+                radialTimeTrace.z[0].length,
+                fixture.expected.radialTimePoints
+            );
+
+            const summary = res.body.results[3].figures;
+            assertFiniteSeries(summary.minor, 'Summary minor radius');
+            assertFiniteSeries(summary.q, 'Summary safety factor');
+            assert.deepEqual(summary.minor, equilibriumTrace.x);
+
+            // Express must be able to serialize the complete response body.
+            assert.doesNotThrow(() => JSON.stringify(res.body));
+        });
+    }
+});

--- a/test/batch-api.test.js
+++ b/test/batch-api.test.js
@@ -1,0 +1,693 @@
+/**
+ * Tests for the POST /plot/data/batch route handler.
+ *
+ * The handler function signature:
+ *   async function batchPlotData(req, res)
+ *
+ * Run with:
+ *   node --test test/batch-api.test.js
+ */
+
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ------------------------------------------------------------------
+//  Mock helpers
+// ------------------------------------------------------------------
+
+/**
+ * Create a mock Express response object.
+ * Captures status code and JSON body so assertions can inspect them.
+ */
+function createMockRes() {
+    const res = {
+        _status: 200,
+        _json: null,
+        status(code) {
+            res._status = code;
+            return res;
+        },
+        json(data) {
+            res._json = data;
+            return res;
+        },
+    };
+    return res;
+}
+
+/**
+ * Create a mock GTCOutput instance.
+ *
+ * @param {Object} [opts]
+ * @param {Object<string, any|Error>} [opts.readDataResults] - Map of type →
+ *   return value (or Error to throw) for readData().
+ * @param {Object<string, any|Error>} [opts.getPlotDataResults] - Map of
+ *   "type-id" → return value (or Error to throw) for getPlotData().
+ * @param {Object} [opts.radialData] - Radial data to expose as
+ *   gtcOutput.data['Equilibrium'].radialData (for Summary tests).
+ */
+function createMockGtcOutput(opts = {}) {
+    const { readDataResults, getPlotDataResults, radialData } = opts;
+    const mock = {
+        data: {},
+        readDataCalls: [],
+        getPlotDataCalls: [],
+        async readData(type) {
+            this.readDataCalls.push(type);
+            if (readDataResults && Object.hasOwn(readDataResults, type)) {
+                const val = readDataResults[type];
+                if (val instanceof Error) throw val;
+                return val;
+            }
+            // Default: succeed silently
+            return undefined;
+        },
+        getPlotData(type, id, query) {
+            this.getPlotDataCalls.push({ type, id, query });
+            if (
+                getPlotDataResults &&
+                Object.hasOwn(getPlotDataResults, `${type}-${id}`)
+            ) {
+                const val = getPlotDataResults[`${type}-${id}`];
+                if (val instanceof Error) throw val;
+                return val;
+            }
+            // Default: return a simple figure
+            return [
+                {
+                    data: [{ y: [1, 2, 3] }],
+                    layout: { title: { text: `${type}-${id}` } },
+                },
+            ];
+        },
+    };
+
+    // Wire up radialData so readData('Equilibrium') populates it
+    if (radialData) {
+        mock.data['Equilibrium'] = { radialData };
+    }
+
+    return mock;
+}
+
+/**
+ * Create a minimal mock Express request.
+ */
+function createMockReq(overrides = {}) {
+    return {
+        body: { gtcOutput: createMockGtcOutput(), requests: [] },
+        query: {},
+        ...overrides,
+    };
+}
+
+// ------------------------------------------------------------------
+//  Tests
+// ------------------------------------------------------------------
+
+describe('POST /plot/data/batch', () => {
+    let batchPlotData;
+
+    before(() => {
+        // This will throw if the module doesn't exist yet (red phase of TDD).
+        batchPlotData =
+            require('../server/batch-data-handler.js').batchPlotData;
+    });
+
+    // ------------------------------------------------------------------
+    //  Validation
+    // ------------------------------------------------------------------
+
+    describe('validation', () => {
+        it('returns 400 when requests is missing', async () => {
+            if (!batchPlotData) return;
+
+            const req = createMockReq({
+                body: { gtcOutput: createMockGtcOutput() },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 400);
+            assert.ok(res._json.error);
+        });
+
+        it('returns 400 when requests is not an array', async () => {
+            if (!batchPlotData) return;
+
+            const req = createMockReq({
+                body: {
+                    gtcOutput: createMockGtcOutput(),
+                    requests: 'not-an-array',
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 400);
+            assert.ok(res._json.error);
+        });
+
+        it('returns 400 when requests is an empty array', async () => {
+            if (!batchPlotData) return;
+
+            const req = createMockReq({
+                body: { gtcOutput: createMockGtcOutput(), requests: [] },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 400);
+            assert.ok(res._json.error);
+        });
+    });
+
+    // ------------------------------------------------------------------
+    //  Happy path
+    // ------------------------------------------------------------------
+
+    describe('successful batch', () => {
+        it('returns figures for multiple items of the same type', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'History', id: 'phi-RMS' },
+                        { type: 'History', id: 'phi-mode1' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+
+            res._json.results.forEach((r, i) => {
+                assert.equal(r.type, 'History');
+                assert.ok(r.figures, `item ${i} should have figures`);
+                assert.equal(
+                    r.error,
+                    undefined,
+                    `item ${i} should not have error`
+                );
+                assert.ok(Array.isArray(r.figures));
+            });
+
+            // readData should only have been called ONCE for History (grouped)
+            const historyCalls = gtcOutput.readDataCalls.filter(
+                c => c === 'History'
+            );
+            assert.equal(
+                historyCalls.length,
+                1,
+                'readData should be called only once per type'
+            );
+        });
+
+        it('returns figures for items across different types', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'Equilibrium', id: '1D-psi-Te' },
+                        { type: 'RadialTime', id: 'phi-zonal' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+
+            res._json.results.forEach(r => {
+                assert.ok(r.figures, `${r.type}-${r.id} should have figures`);
+                assert.equal(r.error, undefined);
+            });
+
+            // readData should have been called once per unique type
+            assert.equal(gtcOutput.readDataCalls.length, 3);
+            assert.ok(gtcOutput.readDataCalls.includes('History'));
+            assert.ok(gtcOutput.readDataCalls.includes('Equilibrium'));
+            assert.ok(gtcOutput.readDataCalls.includes('RadialTime'));
+        });
+
+        it('calls getPlotData with the correct query parameter', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [{ type: 'History', id: 'phi-point' }],
+                },
+                query: { snapshot_playing: '' },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            const call = gtcOutput.getPlotDataCalls[0];
+            assert.deepEqual(call.query, { snapshot_playing: '' });
+        });
+
+        it('preserves result order matching request order', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const requests = [
+                { type: 'History', id: 'zzz-last' },
+                { type: 'History', id: 'aaa-first' },
+                { type: 'Equilibrium', id: 'middle' },
+                { type: 'History', id: 'bbb-second' },
+            ];
+            const req = createMockReq({ body: { gtcOutput, requests } });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._json.results.length, 4);
+            res._json.results.forEach((r, i) => {
+                assert.equal(r.type, requests[i].type);
+                assert.equal(r.id, requests[i].id);
+            });
+        });
+    });
+
+    // ------------------------------------------------------------------
+    //  Partial failures
+    // ------------------------------------------------------------------
+
+    describe('partial failures', () => {
+        it('returns error for an invalid id while valid ids succeed', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput({
+                getPlotDataResults: {
+                    'History-nonexistent': new Error(
+                        'Unknown plot id: nonexistent'
+                    ),
+                },
+            });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'History', id: 'nonexistent' },
+                        { type: 'History', id: 'phi-RMS' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+
+            // phi-point: success
+            assert.ok(res._json.results[0].figures);
+            assert.equal(res._json.results[0].error, undefined);
+
+            // nonexistent: error
+            assert.equal(res._json.results[1].figures, undefined);
+            assert.ok(res._json.results[1].error);
+            assert.match(res._json.results[1].error, /nonexistent/);
+
+            // phi-RMS: still succeeds
+            assert.ok(res._json.results[2].figures);
+            assert.equal(res._json.results[2].error, undefined);
+        });
+
+        it('returns error for all items of a type when readData fails', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput({
+                readDataResults: {
+                    Equilibrium: new Error('equilibrium.out not found'),
+                },
+            });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'Equilibrium', id: '1D-psi-Te' },
+                        { type: 'Equilibrium', id: '1D-rg-q' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+
+            // History should succeed
+            assert.ok(res._json.results[0].figures);
+            assert.equal(res._json.results[0].error, undefined);
+
+            // Equilibrium items should both have errors
+            assert.equal(res._json.results[1].figures, undefined);
+            assert.ok(res._json.results[1].error);
+
+            assert.equal(res._json.results[2].figures, undefined);
+            assert.ok(res._json.results[2].error);
+        });
+
+        it('handles mixed valid and invalid types independently', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput({
+                readDataResults: {
+                    BrokenType: new Error('Cannot read BrokenType'),
+                },
+                getPlotDataResults: {
+                    'History-bad-id': new Error('bad id'),
+                },
+            });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'History', id: 'bad-id' },
+                        { type: 'BrokenType', id: 'something' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+
+            // phi-point: success
+            assert.ok(res._json.results[0].figures);
+            // bad-id: getPlotData error
+            assert.ok(res._json.results[1].error);
+            // BrokenType: readData error
+            assert.ok(res._json.results[2].error);
+        });
+    });
+
+    // ------------------------------------------------------------------
+    //  Summary (reads Equilibrium and extracts radial profiles inline)
+    // ------------------------------------------------------------------
+
+    describe('Summary', () => {
+        it('returns summary data when type is Summary', async () => {
+            if (!batchPlotData) return;
+
+            const radialData = {
+                minor: [0, 0.5, 1.0],
+                rg: [0, 0.5, 1.0],
+                q: [0.8, 1.2, 1.6],
+                Te: [100, 200, 300],
+                Ti: [50, 100, 150],
+            };
+            const gtcOutput = createMockGtcOutput({ radialData });
+
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [{ type: 'Summary', id: 'all' }],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 1);
+            assert.ok(res._json.results[0].figures);
+            assert.deepEqual(res._json.results[0].figures.minor, [0, 0.5, 1.0]);
+            assert.deepEqual(res._json.results[0].figures.q, [0.8, 1.2, 1.6]);
+
+            // Should have called readData('Equilibrium'), not readData('Summary')
+            assert.ok(gtcOutput.readDataCalls.includes('Equilibrium'));
+            assert.ok(!gtcOutput.readDataCalls.includes('Summary'));
+        });
+
+        it('returns error for all Summary items when readData(Equilibrium) fails', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput({
+                readDataResults: {
+                    Equilibrium: new Error('equilibrium.out not found'),
+                },
+            });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [{ type: 'Summary', id: 'all' }],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 1);
+            assert.equal(res._json.results[0].figures, undefined);
+            assert.ok(res._json.results[0].error);
+        });
+
+        it('mixes Summary and regular types in one request', async () => {
+            if (!batchPlotData) return;
+
+            const radialData = { minor: [0, 1], q: [1, 2] };
+            const gtcOutput = createMockGtcOutput({ radialData });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'Summary', id: 'all' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 2);
+
+            // History item
+            assert.ok(Array.isArray(res._json.results[0].figures));
+            // Summary item
+            assert.deepEqual(res._json.results[1].figures.minor, [0, 1]);
+        });
+    });
+
+    // ------------------------------------------------------------------
+    //  Deduplication (readData grouping)
+    // ------------------------------------------------------------------
+
+    describe('readData deduplication', () => {
+        it('calls readData at most once per unique type', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'History', id: 'phi-RMS' },
+                        { type: 'History', id: 'phi-mode1' },
+                        { type: 'History', id: 'phi-mode2' },
+                        { type: 'History', id: 'ion-density' },
+                        { type: 'Equilibrium', id: '1D-psi-Te' },
+                        { type: 'Equilibrium', id: '1D-rg-q' },
+                        { type: 'History', id: 'ion-momentum' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 8);
+
+            // Only 2 unique types → readData called exactly twice
+            assert.equal(
+                gtcOutput.readDataCalls.length,
+                2,
+                'readData should be called exactly twice'
+            );
+            assert.equal(
+                gtcOutput.readDataCalls.filter(c => c === 'History').length,
+                1
+            );
+            assert.equal(
+                gtcOutput.readDataCalls.filter(c => c === 'Equilibrium').length,
+                1
+            );
+
+            // getPlotData should be called 8 times (once per item)
+            assert.equal(gtcOutput.getPlotDataCalls.length, 8);
+        });
+
+        it('Summary calls readData(Equilibrium), not readData(Summary)', async () => {
+            if (!batchPlotData) return;
+
+            const radialData = { minor: [0, 1] };
+            const gtcOutput = createMockGtcOutput({ radialData });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [{ type: 'Summary', id: 'all' }],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            // Must have called readData('Equilibrium'), never 'Summary'
+            assert.ok(
+                gtcOutput.readDataCalls.includes('Equilibrium'),
+                'should call readData(Equilibrium)'
+            );
+            assert.ok(
+                !gtcOutput.readDataCalls.some(c => c === 'Summary'),
+                'should not call readData(Summary)'
+            );
+        });
+
+        it('shares one Equilibrium read between Summary and Equilibrium', async () => {
+            const radialData = { minor: [0, 1], q: [1, 2] };
+            const gtcOutput = createMockGtcOutput({ radialData });
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'Summary', id: 'all' },
+                        { type: 'Equilibrium', id: '1D-minor-q' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(
+                gtcOutput.readDataCalls.filter(type => type === 'Equilibrium')
+                    .length,
+                1
+            );
+        });
+    });
+
+    // ------------------------------------------------------------------
+    //  Edge cases
+    // ------------------------------------------------------------------
+
+    describe('edge cases', () => {
+        it('returns 400 when all entries have an empty type field', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [{ type: '', id: 'something' }],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            // Empty type field → no valid entries → 400
+            assert.equal(res._status, 400);
+        });
+
+        it('returns 400 instead of throwing when every entry is malformed', async () => {
+            const req = createMockReq({
+                body: {
+                    gtcOutput: createMockGtcOutput(),
+                    requests: [null, 42, { type: 'History' }],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 400);
+            assert.ok(res._json.error);
+        });
+
+        it('returns per-item errors for invalid entries in a mixed batch', async () => {
+            const req = createMockReq({
+                body: {
+                    gtcOutput: createMockGtcOutput(),
+                    requests: [
+                        null,
+                        { type: 'History', id: 'phi-point' },
+                        { type: '   ', id: 'phi-RMS' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 3);
+            assert.match(res._json.results[0].error, /non-empty strings/);
+            assert.ok(res._json.results[1].figures);
+            assert.match(res._json.results[2].error, /non-empty strings/);
+            assert.ok(
+                res._json.results.every(result => result !== null),
+                'response should not contain sparse-array null holes'
+            );
+        });
+
+        it('handles duplicate requests identically', async () => {
+            if (!batchPlotData) return;
+
+            const gtcOutput = createMockGtcOutput();
+            const req = createMockReq({
+                body: {
+                    gtcOutput,
+                    requests: [
+                        { type: 'History', id: 'phi-point' },
+                        { type: 'History', id: 'phi-point' },
+                    ],
+                },
+            });
+            const res = createMockRes();
+
+            await batchPlotData(req, res);
+
+            assert.equal(res._status, 200);
+            assert.equal(res._json.results.length, 2);
+            // Both should have figures (duplicates are fine)
+            assert.ok(res._json.results[0].figures);
+            assert.ok(res._json.results[1].figures);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- add a batch plot-data endpoint with ordered per-item results and partial failure handling
- deduplicate underlying data reads, including shared Summary and Equilibrium parsing
- migrate Summary loading to the batch client API
- make repository guidance agent-neutral
- add unit, client, HTTP, and real-data integration coverage

## Verification

- node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js
- 29 tests passed
- client and server Webpack bundles built successfully