### PR TITLE
Improve plotting quality-of-life controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file provides repository guidance for any AI coding agent working with this
 ## Commands
 
 ```bash
-# Development (builds Plotly and a source-mapped client first, then
-# auto-restarts via nodemon; ignores changes in public/ and custom-plotly/)
+# Development (builds Plotly once; nodemon rebuilds the source-mapped client
+# before starting and before each restart triggered by client/server/view changes)
 npm test
 
 # Production start (runs the webpack-bundled server)

--- a/client/components/figure-data-download.js
+++ b/client/components/figure-data-download.js
@@ -1,0 +1,268 @@
+'use strict';
+
+/**
+ * Per-figure data export for Plotly figures.
+ *
+ * Plotly passes the graph div to custom modebar button callbacks.  The graph
+ * div's public `data` property contains the traces as they are currently
+ * plotted, including client-side unit conversions and recalculations.
+ *
+ * @module figure-data-download
+ */
+
+const POINT_FIELDS = [
+    'x',
+    'y',
+    'z',
+    'a',
+    'b',
+    'r',
+    'theta',
+    'lat',
+    'lon',
+    'values',
+    'labels',
+    'text',
+    'hovertext',
+    'ids',
+    'locations',
+    'customdata',
+];
+
+const COLUMN_AXIS_FIELDS = new Set(['x', 'a', 'lon']);
+const ROW_AXIS_FIELDS = new Set(['y', 'b', 'lat']);
+
+function createJsonIcon() {
+    const icon = document.createElement('span');
+    icon.className = 'material-symbols-outlined modebar-material-symbol';
+    icon.textContent = 'file_json';
+    icon.setAttribute('aria-hidden', 'true');
+    return icon;
+}
+
+function csvValue(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    let text;
+    if (typeof value === 'object') {
+        text = JSON.stringify(value);
+    } else {
+        text = String(value);
+    }
+
+    // Prevent spreadsheet applications from interpreting trace labels or
+    // text as formulas. Numeric values are not changed.
+    if (typeof value === 'string' && /^[=+\-@]/.test(text)) {
+        text = `'${text}`;
+    }
+
+    return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function traceFields(trace) {
+    return POINT_FIELDS.filter(field => Array.isArray(trace?.[field]));
+}
+
+function matrixShape(trace, fields) {
+    let rows = 0;
+    let columns = 0;
+
+    for (const field of fields) {
+        const values = trace[field];
+        if (!values.some(Array.isArray)) {
+            continue;
+        }
+        rows = Math.max(rows, values.length);
+        for (const row of values) {
+            if (Array.isArray(row)) {
+                columns = Math.max(columns, row.length);
+            }
+        }
+    }
+
+    return { rows, columns };
+}
+
+function gridValue(values, field, row, column, rows, columns) {
+    if (values.some(Array.isArray)) {
+        return values[row]?.[column];
+    }
+    if (COLUMN_AXIS_FIELDS.has(field)) {
+        return values[column];
+    }
+    if (ROW_AXIS_FIELDS.has(field)) {
+        return values[row];
+    }
+    if (values.length === rows * columns) {
+        return values[row * columns + column];
+    }
+    if (values.length === columns) {
+        return values[column];
+    }
+    if (values.length === rows) {
+        return values[row];
+    }
+    return undefined;
+}
+
+/**
+ * Serialize Plotly trace data to a rectangular, long-form CSV document.
+ *
+ * One-dimensional traces produce one row per point. Matrix traces such as
+ * heatmaps and contours produce one row per cell, with their one-dimensional
+ * x/y (or a/b) axes expanded to the matching column/row coordinate.
+ *
+ * @param {Array<Object>} traces Plotly trace objects.
+ * @returns {string} CSV text without a byte-order mark.
+ */
+export function figureDataToCsv(traces = []) {
+    const fields = [
+        ...new Set(traces.flatMap(trace => traceFields(trace))),
+    ];
+    const header = [
+        'trace_index',
+        'trace_name',
+        'trace_type',
+        'point_index',
+        'row',
+        'column',
+        ...fields,
+    ];
+    const rows = [header.map(csvValue).join(',')];
+
+    traces.forEach((trace, traceIndex) => {
+        const availableFields = traceFields(trace);
+        const { rows: gridRows, columns: gridColumns } = matrixShape(
+            trace,
+            availableFields
+        );
+        const prefix = [
+            traceIndex,
+            trace.name ?? `trace ${traceIndex + 1}`,
+            trace.type ?? 'scatter',
+        ];
+
+        if (gridRows > 0 && gridColumns > 0) {
+            for (let row = 0; row < gridRows; row += 1) {
+                for (let column = 0; column < gridColumns; column += 1) {
+                    const values = fields.map(field =>
+                        availableFields.includes(field)
+                            ? gridValue(
+                                  trace[field],
+                                  field,
+                                  row,
+                                  column,
+                                  gridRows,
+                                  gridColumns
+                              )
+                            : undefined
+                    );
+                    rows.push(
+                        [...prefix, row * gridColumns + column, row, column, ...values]
+                            .map(csvValue)
+                            .join(',')
+                    );
+                }
+            }
+            return;
+        }
+
+        const pointCount = Math.max(
+            0,
+            ...availableFields.map(field => trace[field].length)
+        );
+        for (let point = 0; point < pointCount; point += 1) {
+            rows.push(
+                [
+                    ...prefix,
+                    point,
+                    undefined,
+                    undefined,
+                    ...fields.map(field => trace[field]?.[point]),
+                ]
+                    .map(csvValue)
+                    .join(',')
+            );
+        }
+    });
+
+    return rows.join('\r\n');
+}
+
+/** Serialize the current Plotly trace data without Plotly's private state. */
+export function figureDataToJson(traces = []) {
+    return JSON.stringify(traces, null, 2);
+}
+
+function figureFilename(graphDiv, extension) {
+    const title =
+        typeof graphDiv.layout?.title === 'string'
+            ? graphDiv.layout.title
+            : graphDiv.layout?.title?.text;
+    const base = String(title || graphDiv.id || 'plot-data')
+        .replace(/<[^>]*>/g, '')
+        .replace(/[\\/:*?"<>|]/g, '-')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 100);
+    return `${base || 'plot-data'}.${extension}`;
+}
+
+function downloadBlob(graphDiv, contents, type, extension) {
+    const blob = new Blob(contents, { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = figureFilename(graphDiv, extension);
+    link.hidden = true;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/** Download the currently plotted traces from a Plotly graph div as CSV. */
+export function downloadFigureData(graphDiv) {
+    downloadBlob(
+        graphDiv,
+        ['\ufeff', figureDataToCsv(graphDiv.data)],
+        'text/csv;charset=utf-8',
+        'csv'
+    );
+}
+
+/** Download the currently plotted traces from a Plotly graph div as JSON. */
+export function downloadFigureDataJson(graphDiv) {
+    downloadBlob(
+        graphDiv,
+        [figureDataToJson(graphDiv.data), '\n'],
+        'application/json;charset=utf-8',
+        'json'
+    );
+}
+
+/**
+ * Create Plotly configuration with the per-figure data buttons appended.
+ * Existing custom modebar buttons in `overrides` are preserved.
+ */
+export function createPlotConfig(overrides = {}) {
+    const existingButtons = overrides.modeBarButtonsToAdd ?? [];
+    return {
+        ...overrides,
+        modeBarButtonsToAdd: [
+            ...existingButtons,
+            {
+                name: 'Download plotted data as CSV',
+                icon: Plotly.Icons.disk,
+                click: downloadFigureData,
+            },
+            {
+                name: 'Download plotted data as JSON',
+                icon: createJsonIcon,
+                click: downloadFigureDataJson,
+            },
+        ],
+    };
+}

--- a/client/components/rational-surfaces.js
+++ b/client/components/rational-surfaces.js
@@ -4,12 +4,16 @@
  * Rational-surface controls and overlays for equilibrium q profiles.
  *
  * For a selected toroidal mode number n, the radial position of every
- * q = m/n crossing is drawn as a vertical dotted line.
+ * q = m/n crossing is drawn as a vertical dashed line.
  *
  * @module rational-surfaces
  */
 
 import state from '../control/state.js';
+import {
+    findRationalSurfaceCrossings,
+    RATIONAL_SURFACE_LINE_STYLE,
+} from '../shared/rational-surfaces.js';
 import { refreshPlotRangeControls } from './figure-range-controls.js';
 
 const CONTROL_ID = 'rational-surface-controls';
@@ -61,36 +65,14 @@ export function rationalSurfaceTraces(qTrace, n) {
     const qMax = Math.max(...qs);
     const mMin = Math.ceil(qMin * n);
     const mMax = Math.floor(qMax * n);
-    const traces = [];
+    const modes = Array.from(
+        { length: mMax - mMin + 1 },
+        (_, index) => ({ m: mMin + index, n })
+    );
 
-    for (let m = mMin; m <= mMax; m += 1) {
-        const targetQ = m / n;
-        const radialPositions = [];
-
-        for (let index = 0; index < points.length - 1; index += 1) {
-            const first = points[index];
-            const second = points[index + 1];
-
-            if (first.q === targetQ) {
-                radialPositions.push(first.x);
-            }
-            if (
-                first.q !== second.q &&
-                (targetQ - first.q) * (targetQ - second.q) < 0
-            ) {
-                radialPositions.push(
-                    first.x +
-                        ((targetQ - first.q) / (second.q - first.q)) *
-                            (second.x - first.x)
-                );
-            }
-        }
-        if (points.at(-1).q === targetQ) {
-            radialPositions.push(points.at(-1).x);
-        }
-
-        [...new Set(radialPositions)].forEach(radialPosition => {
-            traces.push({
+    return findRationalSurfaceCrossings(qTrace, modes).map(
+        ({ m, n, radialPosition }) => {
+            return {
                 x: [radialPosition, radialPosition],
                 y: [qMin, qMax],
                 type: 'scatter',
@@ -98,18 +80,12 @@ export function rationalSurfaceTraces(qTrace, n) {
                 name: `m/n = ${m}/${n}`,
                 legendgroup: 'rational-surfaces',
                 showlegend: false,
-                line: {
-                    color: 'rgba(190, 45, 45, 0.65)',
-                    dash: 'dot',
-                    width: 1.5,
-                },
+                line: { ...RATIONAL_SURFACE_LINE_STYLE },
                 hovertemplate: `m=${m}<extra></extra>`,
                 meta: { gtcRationalSurface: true, m, n },
-            });
-        });
-    }
-
-    return traces;
+            };
+        }
+    );
 }
 
 /** Replace any previous rational-surface overlays on a Plotly figure. */

--- a/client/components/rational-surfaces.js
+++ b/client/components/rational-surfaces.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * Rational-surface controls and overlays for equilibrium q profiles.
+ *
+ * For a selected toroidal mode number n, the radial position of every
+ * q = m/n crossing is drawn as a vertical dotted line.
+ *
+ * @module rational-surfaces
+ */
+
+import state from '../control/state.js';
+import { refreshPlotRangeControls } from './figure-range-controls.js';
+
+const CONTROL_ID = 'rational-surface-controls';
+const SLIDER_ID = 'rational-surface-n';
+
+function isRationalSurfaceTrace(trace) {
+    return trace?.meta?.gtcRationalSurface === true;
+}
+
+/** Derive a useful slider range from the configured toroidal modes. */
+export function rationalSurfaceNRange(nModes = []) {
+    const positiveModes = nModes
+        .map(Number)
+        .filter(Number.isFinite)
+        .map(Math.trunc)
+        .filter(n => n > 0);
+
+    return positiveModes.length > 0
+        ? {
+              min: 1,
+              max: Math.max(...positiveModes),
+              initial: positiveModes[0],
+          }
+        : { min: 1, max: 1, initial: 1 };
+}
+
+/**
+ * Build Plotly traces at the radial positions of all q = m/n crossings.
+ *
+ * @param {Object} qTrace Plotly trace containing matching x and y arrays.
+ * @param {number} n Selected positive toroidal mode number.
+ * @returns {Array<Object>}
+ */
+export function rationalSurfaceTraces(qTrace, n) {
+    n = Math.trunc(Number(n));
+    if (n < 1 || !Array.isArray(qTrace?.x) || !Array.isArray(qTrace?.y)) {
+        return [];
+    }
+
+    const points = qTrace.x
+        .map((x, index) => ({ x, q: qTrace.y[index] }))
+        .filter(({ x, q }) => Number.isFinite(x) && Number.isFinite(q));
+    if (points.length === 0) {
+        return [];
+    }
+
+    const qs = points.map(({ q }) => q);
+    const qMin = Math.min(...qs);
+    const qMax = Math.max(...qs);
+    const mMin = Math.ceil(qMin * n);
+    const mMax = Math.floor(qMax * n);
+    const traces = [];
+
+    for (let m = mMin; m <= mMax; m += 1) {
+        const targetQ = m / n;
+        const radialPositions = [];
+
+        for (let index = 0; index < points.length - 1; index += 1) {
+            const first = points[index];
+            const second = points[index + 1];
+
+            if (first.q === targetQ) {
+                radialPositions.push(first.x);
+            }
+            if (
+                first.q !== second.q &&
+                (targetQ - first.q) * (targetQ - second.q) < 0
+            ) {
+                radialPositions.push(
+                    first.x +
+                        ((targetQ - first.q) / (second.q - first.q)) *
+                            (second.x - first.x)
+                );
+            }
+        }
+        if (points.at(-1).q === targetQ) {
+            radialPositions.push(points.at(-1).x);
+        }
+
+        [...new Set(radialPositions)].forEach(radialPosition => {
+            traces.push({
+                x: [radialPosition, radialPosition],
+                y: [qMin, qMax],
+                type: 'scatter',
+                mode: 'lines',
+                name: `m/n = ${m}/${n}`,
+                legendgroup: 'rational-surfaces',
+                showlegend: false,
+                line: {
+                    color: 'rgba(190, 45, 45, 0.65)',
+                    dash: 'dot',
+                    width: 1.5,
+                },
+                hovertemplate: `m=${m}<extra></extra>`,
+                meta: { gtcRationalSurface: true, m, n },
+            });
+        });
+    }
+
+    return traces;
+}
+
+/** Replace any previous rational-surface overlays on a Plotly figure. */
+export function applyRationalSurfaceTraces(figure, n) {
+    const baseTraces = (figure?.data ?? []).filter(
+        trace => !isRationalSurfaceTrace(trace)
+    );
+    if (!figure) {
+        return figure;
+    }
+
+    if (baseTraces[0]) {
+        baseTraces[0].showlegend = false;
+    }
+
+    figure.data = [
+        ...baseTraces,
+        ...rationalSurfaceTraces(baseTraces[0], n),
+    ];
+    return figure;
+}
+
+export function selectedRationalSurfaceN() {
+    const value = Number(document.getElementById(SLIDER_ID)?.value);
+    return Number.isInteger(value) && value > 0 ? value : 1;
+}
+
+export function showRationalSurfaceControl(visible) {
+    const control = document.getElementById(CONTROL_ID);
+    if (control) {
+        control.hidden = !visible;
+    }
+}
+
+/** Add the n slider to the Equilibrium 1D form. */
+export function setupRationalSurfaceControl(panel, nModes) {
+    if (document.getElementById(CONTROL_ID)) {
+        return;
+    }
+
+    const { min, max, initial } = rationalSurfaceNRange(nModes);
+    const control = document.createElement('div');
+    control.id = CONTROL_ID;
+    control.className = 'rational-surface-controls';
+    control.hidden = true;
+
+    const label = document.createElement('label');
+    label.htmlFor = SLIDER_ID;
+    label.append('Rational surfaces for n = ');
+
+    const output = document.createElement('output');
+    output.setAttribute('for', SLIDER_ID);
+    output.textContent = String(initial);
+    label.append(output);
+
+    const slider = document.createElement('input');
+    Object.assign(slider, {
+        id: SLIDER_ID,
+        type: 'range',
+        min: String(min),
+        max: String(max),
+        step: '1',
+        value: String(initial),
+    });
+
+    slider.addEventListener('input', async () => {
+        output.textContent = slider.value;
+        if (!state.current_plot_btn?.id.match(/^Equilibrium-1D-.+-q$/)) {
+            return;
+        }
+
+        const graphDiv = document.getElementById('figure-1');
+        if (!Array.isArray(graphDiv?.data)) {
+            return;
+        }
+
+        applyRationalSurfaceTraces(graphDiv, Number(slider.value));
+        await Plotly.react(graphDiv, graphDiv.data, graphDiv.layout);
+        refreshPlotRangeControls();
+    });
+
+    control.append(label, slider);
+    panel.querySelector('form').append(control);
+}

--- a/client/control/figure-manager.js
+++ b/client/control/figure-manager.js
@@ -50,6 +50,7 @@ import {
     addSimulationRegion,
 } from '../plotting/plot-data-process.js';
 import { buildSummaryPage } from '../plotting/summary-generate.js';
+import { createPlotConfig } from '../components/figure-data-download.js';
 
 // ------------------------------------------------------------------
 //  Helpers
@@ -290,9 +291,9 @@ export async function getDataThenPlot(clean_beforehand = true) {
                       fig_div,
                       data,
                       layout,
-                      {
+                      createPlotConfig({
                           editable: true,
-                      }
+                      })
                   )
                 : Promise.resolve();
         })

--- a/client/control/figure-manager.js
+++ b/client/control/figure-manager.js
@@ -51,6 +51,12 @@ import {
 } from '../plotting/plot-data-process.js';
 import { buildSummaryPage } from '../plotting/summary-generate.js';
 import { createPlotConfig } from '../components/figure-data-download.js';
+import {
+    applyRationalSurfaceTraces,
+    selectedRationalSurfaceN,
+    setupRationalSurfaceControl,
+    showRationalSurfaceControl,
+} from '../components/rational-surfaces.js';
 
 // ------------------------------------------------------------------
 //  Helpers
@@ -277,6 +283,17 @@ export async function getDataThenPlot(clean_beforehand = true) {
         });
     }
 
+    if (this.id.startsWith('Equilibrium')) {
+        const isSafetyFactor = /^Equilibrium-1D-.+-q$/.test(this.id);
+        showRationalSurfaceControl(isSafetyFactor);
+        if (isSafetyFactor && figures[0]) {
+            applyRationalSurfaceTraces(
+                figures[0],
+                selectedRationalSurfaceN()
+            );
+        }
+    }
+
     await Promise.all(
         figures.map(({ data, layout, force_redraw }, idx) => {
             const fig_div = document.querySelector(`#figure-${idx + 1}`);
@@ -371,5 +388,10 @@ function createEqPanel1D(xDataTypes, yDataTypes) {
                 })
             )();
         })
+    );
+
+    setupRationalSurfaceControl(
+        document.getElementById('Equilibrium-panel'),
+        state.basicParameters?.nmodes
     );
 }

--- a/client/control/figure-manager.js
+++ b/client/control/figure-manager.js
@@ -95,7 +95,7 @@ export function cleanPanel() {
         p.style.zIndex = 1;
     }
 
-    const recalculate = panel.querySelector('#History-panel').firstElementChild;
+    const recalculate = panel.querySelector('#history-recalculate');
     if (recalculate) {
         recalculate.classList.remove('active');
     }
@@ -253,8 +253,7 @@ export async function getDataThenPlot(clean_beforehand = true) {
     applyTimeUnitToFigures(this.id, figures);
 
     // some figures need some local calculation
-    const recalculate =
-        document.getElementById('History-panel').firstElementChild;
+    const recalculate = document.getElementById('history-recalculate');
     if (this.id.startsWith('History')) {
         recalculate.classList.remove('active');
     }

--- a/client/plotting/history-recal.js
+++ b/client/plotting/history-recal.js
@@ -15,6 +15,14 @@ import { wrap } from '../components/status-bar.js';
 import { historyMode } from './plot-data-process.js';
 import { refreshPlotRangeControls } from '../components/figure-range-controls.js';
 
+/** Keep the recalculation control visible after its normal position scrolls away. */
+export function updateHistoryRecalPosition(anchor, control) {
+    control.classList.toggle(
+        'history-recalculate-pinned',
+        anchor.getBoundingClientRect().top <= 20
+    );
+}
+
 /**
  * Append the "Recalculate growth rate and frequency" button to `panel`.
  *
@@ -22,6 +30,7 @@ import { refreshPlotRangeControls } from '../components/figure-range-controls.js
  */
 export function addHistoryRecal(panel) {
     const div = document.createElement('div');
+    div.id = 'history-recalculate';
     const btn = document.createElement('button');
     btn.innerText =
         'Recalculate\ngrowth rate and frequency\naccording to zoomed range';
@@ -51,5 +60,14 @@ export function addHistoryRecal(panel) {
     div.classList.add('dropdown');
     div.style['overflow'] = 'hidden';
     div.append(btn);
-    panel.prepend(div);
+
+    const anchor = document.createElement('div');
+    anchor.classList.add('history-recalculate-anchor');
+    const updatePosition = () => updateHistoryRecalPosition(anchor, div);
+
+    panel.append(anchor);
+    panel.append(div);
+    window.addEventListener('scroll', updatePosition, { passive: true });
+    window.addEventListener('resize', updatePosition);
+    updatePosition();
 }

--- a/client/plotting/plot-data-process.js
+++ b/client/plotting/plot-data-process.js
@@ -7,6 +7,7 @@
 
 import state from '../control/state.js';
 import { interleave, unInterleave } from '../shared/util.js';
+import { createPlotConfig } from '../components/figure-data-download.js';
 export async function historyMode(figures, interval1 = null, interval2 = null) {
     // `interval1`/`interval2` are user-selected zoom ranges (as fractions of
     // the total data length) coming from the rangesliders. When they are
@@ -114,7 +115,12 @@ export async function trackingPlot(figures) {
     const zeta = figures.pop().extraData;
 
     const figureDiv1 = document.getElementById('figure-1');
-    await Plotly.newPlot(figureDiv1, figures[0]);
+    await Plotly.newPlot(
+        figureDiv1,
+        figures[0].data,
+        figures[0].layout,
+        createPlotConfig({ editable: true })
+    );
 
     // Plotly will do the spline for me
     const [carpet, scatter] = figureDiv1.calcdata;
@@ -125,7 +131,12 @@ export async function trackingPlot(figures) {
         z: scatter.map(({ y }) => y),
     });
 
-    Plotly.newPlot('figure-2', figures[1]);
+    Plotly.newPlot(
+        'figure-2',
+        figures[1].data,
+        figures[1].layout,
+        createPlotConfig({ editable: true })
+    );
 }
 
 export function addSimulationRegion(fig) {

--- a/client/plotting/snapshot.js
+++ b/client/plotting/snapshot.js
@@ -22,6 +22,10 @@ import state from '../control/state.js';
 import { requestPlotData } from '../shared/api.js';
 import { getStatusBar } from '../components/status-bar.js';
 import { interleave, unInterleave, min_max } from '../shared/util.js';
+import {
+    findRationalSurfaceCrossings,
+    RATIONAL_SURFACE_LINE_STYLE,
+} from '../shared/rational-surfaces.js';
 
 // ==================================================================
 //  Internal helpers
@@ -70,7 +74,7 @@ function getTicks([min, max], num) {
 }
 
 function getRationalSurface(safetyFactor, n_modes, m_modes) {
-    const mode_num = n_modes
+    const modes = n_modes
         .map((n, i) => {
             return { n: n, m: m_modes[i] };
         })
@@ -79,29 +83,19 @@ function getRationalSurface(safetyFactor, n_modes, m_modes) {
             const last_item = ary[!pos ? 0 : pos - 1];
             return !pos || item.m * last_item.n != item.n * last_item.m;
         });
-    const linear_map = (t, x0, x1, y0, y1) =>
-        y0 + ((y1 - y0) * (t - x0)) / (x1 - x0);
-
-    const result = [];
     const [r0, r1] = state.basicParameters.radial_region;
-    for (let i = 0; i < safetyFactor.x.length - 1; ++i) {
-        if (safetyFactor.x[i + 1] < r0 || safetyFactor.x[i] > r1) {
-            continue;
-        }
-        mode_num.forEach(mode => {
-            const pos = linear_map(
-                mode.m / mode.n,
-                safetyFactor.y[i],
-                safetyFactor.y[i + 1],
-                safetyFactor.x[i],
-                safetyFactor.x[i + 1]
-            );
-            if (pos >= safetyFactor.x[i] && pos < safetyFactor.x[i + 1]) {
-                result.push({ r: (pos - r0) / (r1 - r0), ...mode });
-            }
-        });
-    }
-    return result;
+    const radialMin = Math.min(r0, r1);
+    const radialMax = Math.max(r0, r1);
+
+    return findRationalSurfaceCrossings(safetyFactor, modes)
+        .filter(
+            ({ radialPosition }) =>
+                radialPosition >= radialMin && radialPosition <= radialMax
+        )
+        .map(({ radialPosition, ...mode }) => ({
+            r: (radialPosition - r0) / (r1 - r0),
+            ...mode,
+        }));
 }
 
 // ==================================================================
@@ -498,7 +492,7 @@ export async function snapshotPoloidal(figures, safetyFactor, quick, playing) {
     const { polNum, radNum } = figures.pop();
 
     const flattenedField = figures[0].data[1].z;
-    const diagFluxLineColor = 'rgba(142.846, 176.35, 49.6957, 0.9)';
+    const diagFluxLineColor = RATIONAL_SURFACE_LINE_STYLE.color;
     const diagFlux =
         state.basicParameters.diag_flux ?? state.basicParameters.iflux;
 
@@ -665,11 +659,7 @@ export async function snapshotPoloidal(figures, safetyFactor, quick, playing) {
                     mode: 'lines',
                     showlegend: false,
                     hoverinfo: 'name',
-                    line: {
-                        color: diagFluxLineColor,
-                        dash: 'dash',
-                        width: 1,
-                    },
+                    line: { ...RATIONAL_SURFACE_LINE_STYLE },
                 };
             })
         );

--- a/client/plotting/summary-generate.js
+++ b/client/plotting/summary-generate.js
@@ -6,6 +6,7 @@ import {
 } from '../components/status-bar.js';
 import { getBasicParameters } from '../components/units.js';
 import { requestBatchPlotData } from '../shared/api.js';
+import { createPlotConfig } from '../components/figure-data-download.js';
 
 export async function generateSummary(data) {
     const container = document.querySelector('#container');
@@ -420,7 +421,8 @@ function multipleTraceFigure(container, button, abscissa, ordinates) {
                     title: title,
                     paper_bgcolor: 'rgb(227,248,241)',
                     plot_bgcolor: 'rgb(227,248,241)',
-                }
+                },
+                createPlotConfig()
             );
         }
 

--- a/client/shared/rational-surfaces.js
+++ b/client/shared/rational-surfaces.js
@@ -1,0 +1,69 @@
+'use strict';
+
+export const RATIONAL_SURFACE_LINE_STYLE = Object.freeze({
+    color: 'rgba(142.846, 176.35, 49.6957, 0.9)',
+    dash: 'dash',
+    width: 1,
+});
+
+/**
+ * Locate q = m/n crossings by linearly interpolating a sampled q profile.
+ *
+ * A mode can produce more than one result when the profile is non-monotonic.
+ * Invalid modes and profile points are ignored.
+ *
+ * @param {{x: Array<number>, y: Array<number>}} qTrace
+ * @param {Array<{m: number, n: number}>} modes
+ * @returns {Array<{m: number, n: number, radialPosition: number}>}
+ */
+export function findRationalSurfaceCrossings(qTrace, modes = []) {
+    if (!Array.isArray(qTrace?.x) || !Array.isArray(qTrace?.y)) {
+        return [];
+    }
+
+    const points = qTrace.x
+        .map((x, index) => ({ x: Number(x), q: Number(qTrace.y[index]) }))
+        .filter(({ x, q }) => Number.isFinite(x) && Number.isFinite(q));
+    if (points.length === 0) {
+        return [];
+    }
+
+    const crossings = [];
+    for (const mode of modes) {
+        const m = Number(mode?.m);
+        const n = Number(mode?.n);
+        if (!Number.isFinite(m) || !Number.isFinite(n) || n === 0) {
+            continue;
+        }
+
+        const targetQ = m / n;
+        const radialPositions = [];
+        for (let index = 0; index < points.length - 1; index += 1) {
+            const first = points[index];
+            const second = points[index + 1];
+
+            if (first.q === targetQ) {
+                radialPositions.push(first.x);
+            }
+            if (
+                first.q !== second.q &&
+                (targetQ - first.q) * (targetQ - second.q) < 0
+            ) {
+                radialPositions.push(
+                    first.x +
+                        ((targetQ - first.q) / (second.q - first.q)) *
+                            (second.x - first.x)
+                );
+            }
+        }
+        if (points.at(-1).q === targetQ) {
+            radialPositions.push(points.at(-1).x);
+        }
+
+        [...new Set(radialPositions)].forEach(radialPosition => {
+            crossings.push({ m, n, radialPosition });
+        });
+    }
+
+    return crossings;
+}

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,3 +1,6 @@
 {
-    "ignore": ["public/*", "custom-plotly/*"]
+    "watch": ["client", "server", "views"],
+    "ext": "js,json,pug",
+    "ignore": ["public/**", "custom-plotly/**"],
+    "exec": "npm run pack-client:dev && node ./server/server.js"
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "Online plotting tools for GTC.",
     "main": "server.js",
     "scripts": {
-        "pretest": "npm run pack-custom-plotly && npm run pack-client:dev",
-        "test": "nodemon ./server/server.js",
+        "pretest": "npm run pack-custom-plotly",
+        "test": "nodemon",
         "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js test/history-recal.test.js test/rational-surfaces.test.js",
         "test:batch:real": "node --test test/batch-api-real-data.test.js",
         "start": "node ./server-prod.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "pretest": "npm run pack-custom-plotly && npm run pack-client:dev",
         "test": "nodemon ./server/server.js",
-        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js",
+        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js test/history-recal.test.js",
         "test:batch:real": "node --test test/batch-api-real-data.test.js",
         "start": "node ./server-prod.js",
         "validate-input-parameters": "node ./util/validate-input-parameters.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "pretest": "npm run pack-custom-plotly && npm run pack-client:dev",
         "test": "nodemon ./server/server.js",
-        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js test/history-recal.test.js",
+        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js test/history-recal.test.js test/rational-surfaces.test.js",
         "test:batch:real": "node --test test/batch-api-real-data.test.js",
         "start": "node ./server-prod.js",
         "validate-input-parameters": "node ./util/validate-input-parameters.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "pretest": "npm run pack-custom-plotly && npm run pack-client:dev",
         "test": "nodemon ./server/server.js",
-        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js",
+        "test:batch": "node --test test/batch-api.test.js test/batch-api-client.test.js test/batch-api-http.test.js test/batch-api-real-data.test.js test/figure-data-download.test.js",
         "test:batch:real": "node --test test/batch-api-real-data.test.js",
         "start": "node ./server-prod.js",
         "validate-input-parameters": "node ./util/validate-input-parameters.js",

--- a/public/stylesheets/tabs.css
+++ b/public/stylesheets/tabs.css
@@ -18,6 +18,17 @@
     direction: ltr;
 }
 
+.js-plotly-plot .modebar-btn .modebar-material-symbol {
+    position: relative;
+    top: 1px;
+    color: rgba(68, 68, 68, 0.3);
+    font-size: 18px;
+}
+
+.js-plotly-plot .modebar-btn:hover .modebar-material-symbol {
+    color: rgba(68, 68, 68, 0.7);
+}
+
 :root {
     --preview-bg: azure;
 }

--- a/public/stylesheets/tabs.css
+++ b/public/stylesheets/tabs.css
@@ -357,6 +357,32 @@ div header {
     display: block;
 }
 
+.tabs-l1 > .history-recalculate-anchor {
+    display: block;
+    height: 0;
+    margin: 0;
+}
+
+#history-recalculate {
+    margin-bottom: 0;
+    padding: 0.4rem 0;
+}
+
+#history-recalculate.history-recalculate-pinned {
+    position: fixed;
+    top: 20px;
+    left: 16.45%;
+    width: 17.1%;
+    z-index: 3;
+    box-sizing: border-box;
+    background-color: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.08);
+}
+
+#history-recalculate > .tab-l1-btn {
+    width: 60%;
+}
+
 .plot-range-controls {
     margin: 0.5rem 0 1rem;
     padding: 0.75rem 0.6rem;

--- a/public/stylesheets/tabs.css
+++ b/public/stylesheets/tabs.css
@@ -472,6 +472,29 @@ form {
     margin: 0.5rem 0 2rem;
 }
 
+.rational-surface-controls {
+    display: grid;
+    gap: 0.35rem;
+    margin: 1rem 0.2rem 0;
+    padding: 0.6rem;
+    border: 1px solid rgb(172, 210, 197);
+    border-radius: 8px;
+    background-color: rgba(227, 248, 241, 0.55);
+}
+
+.rational-surface-controls[hidden] {
+    display: none;
+}
+
+.rational-surface-controls > input[type='range'] {
+    width: 100%;
+    margin: 0;
+}
+
+.rational-surface-controls output {
+    font-weight: bold;
+}
+
 #eq-x,
 #eq-y {
     display: grid;

--- a/test/figure-data-download.test.js
+++ b/test/figure-data-download.test.js
@@ -1,0 +1,272 @@
+/**
+ * Tests for per-figure Plotly data downloads.
+ *
+ * Run with:
+ *   node --test test/figure-data-download.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('figure data download', () => {
+    let figureDataToCsv;
+    let figureDataToJson;
+    let createPlotConfig;
+    let downloadFigureData;
+    let downloadFigureDataJson;
+    let originalPlotly;
+
+    beforeEach(async () => {
+        originalPlotly = global.Plotly;
+        global.Plotly = {
+            Icons: {
+                disk: { path: 'disk-icon' },
+            },
+        };
+
+        ({
+            figureDataToCsv,
+            figureDataToJson,
+            createPlotConfig,
+            downloadFigureData,
+            downloadFigureDataJson,
+        } = await import('../client/components/figure-data-download.js'));
+    });
+
+    afterEach(() => {
+        if (originalPlotly === undefined) {
+            delete global.Plotly;
+        } else {
+            global.Plotly = originalPlotly;
+        }
+    });
+
+    it('exports one-dimensional traces as long-form CSV rows', () => {
+        const csv = figureDataToCsv([
+            {
+                name: 'wave, "A"',
+                type: 'scatter',
+                x: [0, 1],
+                y: [2, 3],
+                text: ['plain', '=SUM(A1:A2)'],
+            },
+        ]);
+
+        assert.equal(
+            csv,
+            [
+                'trace_index,trace_name,trace_type,point_index,row,column,x,y,text',
+                '0,"wave, ""A""",scatter,0,,,0,2,plain',
+                "0,\"wave, \"\"A\"\"\",scatter,1,,,1,3,'=SUM(A1:A2)",
+            ].join('\r\n')
+        );
+    });
+
+    it('expands heatmap axes into one row per matrix cell', () => {
+        const csv = figureDataToCsv([
+            {
+                name: 'temperature',
+                type: 'heatmap',
+                x: [10, 20],
+                y: [1, 2],
+                z: [
+                    [3, 4],
+                    [5, 6],
+                ],
+            },
+        ]);
+        const rows = csv.split('\r\n');
+
+        assert.equal(
+            rows[0],
+            'trace_index,trace_name,trace_type,point_index,row,column,x,y,z'
+        );
+        assert.deepEqual(rows.slice(1), [
+            '0,temperature,heatmap,0,0,0,10,1,3',
+            '0,temperature,heatmap,1,0,1,20,1,4',
+            '0,temperature,heatmap,2,1,0,10,2,5',
+            '0,temperature,heatmap,3,1,1,20,2,6',
+        ]);
+    });
+
+    it('preserves complete nested trace data in JSON', () => {
+        const traces = [
+            {
+                name: 'temperature',
+                type: 'heatmap',
+                z: [
+                    [1, 2],
+                    [3, 4],
+                ],
+                colorbar: { title: { text: 'T' } },
+            },
+        ];
+
+        assert.deepEqual(JSON.parse(figureDataToJson(traces)), traces);
+        assert.match(figureDataToJson(traces), /\n  \{/);
+    });
+
+    it('preserves existing modebar buttons and appends both data buttons', () => {
+        const existing = { name: 'Existing button' };
+        const config = createPlotConfig({
+            editable: true,
+            modeBarButtonsToAdd: [existing],
+        });
+
+        assert.equal(config.editable, true);
+        assert.equal(config.modeBarButtonsToAdd[0], existing);
+        assert.equal(config.modeBarButtonsToAdd[1].icon.path, 'disk-icon');
+        assert.equal(
+            config.modeBarButtonsToAdd[1].name,
+            'Download plotted data as CSV'
+        );
+        assert.equal(config.modeBarButtonsToAdd[1].click, downloadFigureData);
+        assert.equal(typeof config.modeBarButtonsToAdd[2].icon, 'function');
+        assert.equal(
+            config.modeBarButtonsToAdd[2].name,
+            'Download plotted data as JSON'
+        );
+        assert.equal(
+            config.modeBarButtonsToAdd[2].click,
+            downloadFigureDataJson
+        );
+
+        const originalDocument = global.document;
+        global.document = {
+            createElement(tag) {
+                assert.equal(tag, 'span');
+                return {
+                    setAttribute(name, value) {
+                        this[name] = value;
+                    },
+                };
+            },
+        };
+        try {
+            const icon = config.modeBarButtonsToAdd[2].icon();
+            assert.equal(
+                icon.className,
+                'material-symbols-outlined modebar-material-symbol'
+            );
+            assert.equal(icon.textContent, 'file_json');
+            assert.equal(icon['aria-hidden'], 'true');
+        } finally {
+            global.document = originalDocument;
+        }
+    });
+
+    it('downloads current graph data with a title-derived filename', async () => {
+        const originalDocument = global.document;
+        const originalUrl = global.URL;
+        const originalSetTimeout = global.setTimeout;
+        let appendedLink;
+        let clicked = false;
+        let removed = false;
+        let downloadedBlob;
+        let revokedUrl;
+
+        global.document = {
+            createElement(tag) {
+                assert.equal(tag, 'a');
+                return {
+                    click() {
+                        clicked = true;
+                    },
+                    remove() {
+                        removed = true;
+                    },
+                };
+            },
+            body: {
+                appendChild(link) {
+                    appendedLink = link;
+                },
+            },
+        };
+        global.URL = {
+            createObjectURL(blob) {
+                downloadedBlob = blob;
+                return 'blob:test';
+            },
+            revokeObjectURL(url) {
+                revokedUrl = url;
+            },
+        };
+        global.setTimeout = callback => callback();
+
+        try {
+            downloadFigureData({
+                id: 'figure-1',
+                data: [{ x: [1], y: [2] }],
+                layout: { title: { text: 'Growth / rate' } },
+            });
+
+            assert.equal(appendedLink.href, 'blob:test');
+            assert.equal(appendedLink.download, 'Growth - rate.csv');
+            assert.equal(appendedLink.hidden, true);
+            assert.equal(clicked, true);
+            assert.equal(removed, true);
+            assert.equal(revokedUrl, 'blob:test');
+            const bytes = new Uint8Array(await downloadedBlob.arrayBuffer());
+            assert.deepEqual([...bytes.slice(0, 3)], [0xef, 0xbb, 0xbf]);
+            assert.match(await downloadedBlob.text(), /^trace_index,/);
+        } finally {
+            global.document = originalDocument;
+            global.URL = originalUrl;
+            global.setTimeout = originalSetTimeout;
+        }
+    });
+
+    it('downloads current graph data as JSON', async () => {
+        const originalDocument = global.document;
+        const originalUrl = global.URL;
+        const originalSetTimeout = global.setTimeout;
+        let link;
+        let downloadedBlob;
+
+        global.document = {
+            createElement() {
+                return {
+                    click() {},
+                    remove() {},
+                };
+            },
+            body: {
+                appendChild(element) {
+                    link = element;
+                },
+            },
+        };
+        global.URL = {
+            createObjectURL(blob) {
+                downloadedBlob = blob;
+                return 'blob:json-test';
+            },
+            revokeObjectURL() {},
+        };
+        global.setTimeout = callback => callback();
+
+        const traces = [{ type: 'scatter3d', x: [1], y: [2], z: [3] }];
+        try {
+            downloadFigureDataJson({
+                id: 'figure-2',
+                data: traces,
+                layout: {},
+            });
+
+            assert.equal(link.href, 'blob:json-test');
+            assert.equal(link.download, 'figure-2.json');
+            assert.equal(
+                downloadedBlob.type,
+                'application/json;charset=utf-8'
+            );
+            assert.deepEqual(JSON.parse(await downloadedBlob.text()), traces);
+        } finally {
+            global.document = originalDocument;
+            global.URL = originalUrl;
+            global.setTimeout = originalSetTimeout;
+        }
+    });
+});

--- a/test/history-recal.test.js
+++ b/test/history-recal.test.js
@@ -1,0 +1,50 @@
+/** Tests for History recalculation control positioning. */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('History recalculation control positioning', () => {
+    it('pins when the control anchor reaches its top offset', async () => {
+        const originalWindow = global.window;
+        global.window = {};
+        let updateHistoryRecalPosition;
+        try {
+            ({ updateHistoryRecalPosition } = await import(
+                '../client/plotting/history-recal.js'
+            ));
+        } finally {
+            global.window = originalWindow;
+        }
+        const classes = new Set();
+        const control = {
+            classList: {
+                toggle(name, enabled) {
+                    if (enabled) {
+                        classes.add(name);
+                    } else {
+                        classes.delete(name);
+                    }
+                },
+            },
+        };
+        let anchorTop = 21;
+        const anchor = {
+            getBoundingClientRect() {
+                return { top: anchorTop };
+            },
+        };
+
+        updateHistoryRecalPosition(anchor, control);
+        assert.equal(classes.has('history-recalculate-pinned'), false);
+
+        anchorTop = 20;
+        updateHistoryRecalPosition(anchor, control);
+        assert.equal(classes.has('history-recalculate-pinned'), true);
+
+        anchorTop = 50;
+        updateHistoryRecalPosition(anchor, control);
+        assert.equal(classes.has('history-recalculate-pinned'), false);
+    });
+});

--- a/test/rational-surfaces.test.js
+++ b/test/rational-surfaces.test.js
@@ -9,6 +9,7 @@ describe('equilibrium rational surfaces', () => {
     let rationalSurfaceNRange;
     let rationalSurfaceTraces;
     let applyRationalSurfaceTraces;
+    let findRationalSurfaceCrossings;
     let originalWindow;
 
     before(async () => {
@@ -19,6 +20,9 @@ describe('equilibrium rational surfaces', () => {
             rationalSurfaceTraces,
             applyRationalSurfaceTraces,
         } = await import('../client/components/rational-surfaces.js'));
+        ({ findRationalSurfaceCrossings } = await import(
+            '../client/shared/rational-surfaces.js'
+        ));
     });
 
     after(() => {
@@ -63,7 +67,11 @@ describe('equilibrium rational surfaces', () => {
         assert.deepEqual(traces[0].y, [1.1, 2.6]);
         assert.ok(Math.abs(traces[1].x[0] - 8 / 7) < 1e-12);
         assert.ok(Math.abs(traces[2].x[0] - 13 / 7) < 1e-12);
-        assert.equal(traces[0].line.dash, 'dot');
+        assert.deepEqual(traces[0].line, {
+            color: 'rgba(142.846, 176.35, 49.6957, 0.9)',
+            dash: 'dash',
+            width: 1,
+        });
         assert.equal(traces[0].hovertemplate, 'm=3<extra></extra>');
     });
 
@@ -83,6 +91,26 @@ describe('equilibrium rational surfaces', () => {
             [
                 [0.5, 0.5],
                 [1.5, 1.5],
+            ]
+        );
+    });
+
+    it('shares crossing interpolation across plotting contexts', () => {
+        assert.deepEqual(
+            findRationalSurfaceCrossings(
+                {
+                    x: [0, 1, 2],
+                    y: [1, 2, 1],
+                },
+                [
+                    { m: 3, n: 2 },
+                    { m: 2, n: 1 },
+                ]
+            ),
+            [
+                { m: 3, n: 2, radialPosition: 0.5 },
+                { m: 3, n: 2, radialPosition: 1.5 },
+                { m: 2, n: 1, radialPosition: 1 },
             ]
         );
     });

--- a/test/rational-surfaces.test.js
+++ b/test/rational-surfaces.test.js
@@ -1,0 +1,121 @@
+/** Tests for equilibrium rational-surface overlays. */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('equilibrium rational surfaces', () => {
+    let rationalSurfaceNRange;
+    let rationalSurfaceTraces;
+    let applyRationalSurfaceTraces;
+    let originalWindow;
+
+    before(async () => {
+        originalWindow = global.window;
+        global.window = {};
+        ({
+            rationalSurfaceNRange,
+            rationalSurfaceTraces,
+            applyRationalSurfaceTraces,
+        } = await import('../client/components/rational-surfaces.js'));
+    });
+
+    after(() => {
+        if (originalWindow === undefined) {
+            delete global.window;
+        } else {
+            global.window = originalWindow;
+        }
+    });
+
+    it('derives the slider maximum and initial n from configured modes', () => {
+        assert.deepEqual(rationalSurfaceNRange([12, 4, 8, 0]), {
+            min: 1,
+            max: 12,
+            initial: 12,
+        });
+        assert.deepEqual(rationalSurfaceNRange([]), {
+            min: 1,
+            max: 1,
+            initial: 1,
+        });
+    });
+
+    it('creates vertical lines at interpolated m/n crossing positions', () => {
+        const traces = rationalSurfaceTraces(
+            {
+                x: [0, 1, 2],
+                y: [1.1, 1.9, 2.6],
+            },
+            2
+        );
+
+        assert.deepEqual(
+            traces.map(trace => [trace.meta.m, trace.meta.n]),
+            [
+                [3, 2],
+                [4, 2],
+                [5, 2],
+            ]
+        );
+        assert.deepEqual(traces[0].x, [0.5, 0.5]);
+        assert.deepEqual(traces[0].y, [1.1, 2.6]);
+        assert.ok(Math.abs(traces[1].x[0] - 8 / 7) < 1e-12);
+        assert.ok(Math.abs(traces[2].x[0] - 13 / 7) < 1e-12);
+        assert.equal(traces[0].line.dash, 'dot');
+        assert.equal(traces[0].hovertemplate, 'm=3<extra></extra>');
+    });
+
+    it('marks every radial crossing on a non-monotonic q profile', () => {
+        const traces = rationalSurfaceTraces(
+            {
+                x: [0, 1, 2],
+                y: [1, 2, 1],
+            },
+            2
+        );
+
+        assert.deepEqual(
+            traces
+                .filter(trace => trace.meta.m === 3)
+                .map(trace => trace.x),
+            [
+                [0.5, 0.5],
+                [1.5, 1.5],
+            ]
+        );
+    });
+
+    it('replaces old rational-surface traces without touching q data', () => {
+        const qTrace = { x: [0, 1], y: [1, 2] };
+        const figure = {
+            data: [
+                qTrace,
+                {
+                    x: [0.5, 0.5],
+                    y: [1, 2],
+                    meta: { gtcRationalSurface: true, m: 3, n: 2 },
+                },
+            ],
+        };
+
+        applyRationalSurfaceTraces(figure, 1);
+
+        assert.equal(figure.data[0], qTrace);
+        assert.equal(qTrace.showlegend, false);
+        assert.equal(figure.data.length, 3);
+        assert.deepEqual(
+            figure.data.slice(1).map(trace => trace.meta),
+            [
+                { gtcRationalSurface: true, m: 1, n: 1 },
+                { gtcRationalSurface: true, m: 2, n: 1 },
+            ]
+        );
+    });
+
+    it('returns no surfaces for invalid n or incomplete data', () => {
+        assert.deepEqual(rationalSurfaceTraces({ x: [0], y: [1] }, 0), []);
+        assert.deepEqual(rationalSurfaceTraces({ x: [], y: [] }, 2), []);
+    });
+});


### PR DESCRIPTION
## Summary

- add CSV and JSON downloads for the data currently plotted in each figure
- keep the history recalculation control visible while scrolling
- add an n slider that marks rational-surface radial positions with vertical lines and m hover labels
- rebuild the development client before each nodemon restart

## Verification

- `npm run test:batch` (41 tests passed)
- `npm run pack-client:dev`

Closes #8
Closes #18
Closes #29