### PR TITLE
Fix FFTE build in release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,13 +33,13 @@ jobs:
 
       - name: Build and test FFTE WebAssembly
         run: |
-          emcmake cmake -S ffte -B ffte/build-wasm -DFFTE_BUILD_TESTS=OFF
-          cmake --build ffte/build-wasm --target ffte_wasm
+          emcmake cmake -S ffte -B ffte/build-wasm \
+            -DFFTE_BUILD_TESTS=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build ffte/build-wasm --target ffte_wasm --config Release
           mkdir -p ffte/dist public/libs/ffte
           cp ffte/build-wasm/ffte.wasm ffte/dist/ffte.wasm
-          cp ffte/js/ffte.mjs ffte/dist/ffte.js
           cp ffte/dist/ffte.wasm public/libs/ffte/ffte.wasm
-          cp ffte/dist/ffte.js public/libs/ffte/ffte.js
           node ffte/tests/test_wasm.mjs
 
       - name: Build release package


### PR DESCRIPTION
Summary:
- configure the FFTE WebAssembly build with CMake Release mode
- build the Release target explicitly
- stop regenerating the already tracked JavaScript wrapper during packaging

Cause:
The unoptimized Emscripten build retained WASI filesystem imports (fd_close, fd_write, and fd_seek), so the standalone-module import assertion failed. Release mode removes those unused imports and matches the verified FFTE CI build.

Verification:
- local Release-mode FFTE WASM build
- node ffte/tests/test_wasm.mjs
- npm run pack